### PR TITLE
Autohide empty placeholder description

### DIFF
--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.html
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.html
@@ -20,6 +20,7 @@
             [commentForm]="this.newIssueForm"
             [(isFormPending)]="this.isFormPending"
             [(submitButtonText)]="this.submitButtonText"
+            [(defaultValue)]="this.defaultValue"
             >
           </app-comment-editor>
         </div>

--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.html
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.html
@@ -19,7 +19,8 @@
             [commentField]="description"
             [commentForm]="this.newIssueForm"
             [(isFormPending)]="this.isFormPending"
-            [(submitButtonText)]="this.submitButtonText">
+            [(submitButtonText)]="this.submitButtonText"
+            >
           </app-comment-editor>
         </div>
 

--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
@@ -19,7 +19,7 @@ export class NewIssueComponent implements OnInit {
   isFormPending = false;
 
   submitButtonText: string;
-
+  defaultValue = 'No details provided.';
   constructor(private issueService: IssueService, private formBuilder: FormBuilder,
               private errorHandlingService: ErrorHandlingService, public labelService: LabelService,
               private router: Router,

--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
@@ -7,6 +7,7 @@ import { Router } from '@angular/router';
 import { finalize } from 'rxjs/operators';
 import { LabelService } from '../../core/services/label.service';
 import { SUBMIT_BUTTON_TEXT } from '../../shared/view-issue/view-issue.component';
+import { LoggingService } from '../../core/services/logging.service';
 
 @Component({
   selector: 'app-new-issue',
@@ -21,15 +22,19 @@ export class NewIssueComponent implements OnInit {
 
   constructor(private issueService: IssueService, private formBuilder: FormBuilder,
               private errorHandlingService: ErrorHandlingService, public labelService: LabelService,
-              private router: Router) { }
+              private router: Router,
+              private logger: LoggingService) { }
 
   ngOnInit() {
+    this.logger.startSession();
+
     this.newIssueForm = this.formBuilder.group({
       title: ['', Validators.required],
       description: ['No details provided.'],
       severity: ['', Validators.required],
       type: ['', Validators.required],
     });
+    this.logger.info("reach here");
 
     this.submitButtonText = SUBMIT_BUTTON_TEXT.SUBMIT;
   }

--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
@@ -34,8 +34,7 @@ export class NewIssueComponent implements OnInit {
       severity: ['', Validators.required],
       type: ['', Validators.required],
     });
-    this.logger.info("reach here");
-
+    
     this.submitButtonText = SUBMIT_BUTTON_TEXT.SUBMIT;
   }
 

--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
@@ -34,7 +34,6 @@ export class NewIssueComponent implements OnInit {
       severity: ['', Validators.required],
       type: ['', Validators.required],
     });
-    
     this.submitButtonText = SUBMIT_BUTTON_TEXT.SUBMIT;
   }
 

--- a/src/app/shared/comment-editor/comment-editor.component.html
+++ b/src/app/shared/comment-editor/comment-editor.component.html
@@ -10,7 +10,10 @@
           <textarea (paste)="onPaste($event)" #commentTextArea (dragover)="disableCaretMovement($event)"
                     id="{{ this.id }}" formControlName="{{ this.id }}" matInput placeholder="Description"
                     cdkTextareaAutosize #autosize="cdkTextareaAutosize" cdkAutosizeMinRows="10"
-                    cdkAutosizeMaxRows="20" class="text-input-area"></textarea>
+                    cdkAutosizeMaxRows="20" class="text-input-area" 
+                    (focus)="checkPlaceHolderOnFocus()"
+                    (blur)="checkPlaceHolderOnBlur()"
+                    ></textarea>
           <mat-error *ngIf="commentField.errors && commentField.errors['required'] && commentField.touched">
             Description required.
           </mat-error>

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -80,22 +80,17 @@ export class CommentEditorComponent implements OnInit {
   }
 
   checkPlaceHolderOnFocus() {
-    this.logger.info("onfocus event");
-    this.logger.info("commentField value: " + this.commentField.value);
-    this.logger.info("initial value: " + this.initialDescription);
     if (this.commentField.value === 'No details provided.') {
       this.commentField.setValue('');
     }
   }
 
   checkPlaceHolderOnBlur() {
-    this.logger.info("blur event");
-    this.logger.info("commentField value: " + this.commentField.value);
-    this.logger.info("initial value: " + this.initialDescription);
     if (this.commentField.value === '') {
       this.commentField.setValue('No details provided.');
     }
   }
+
   // Prevent cursor in textarea from moving when file is dragged over it.
   disableCaretMovement(event) {
     event.preventDefault();

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -33,6 +33,7 @@ export class CommentEditorComponent implements OnInit {
   @Input() id: string; // Compulsory Input
 
   @Input() initialDescription?: string;
+  @Input() defaultValue?: string;
 
   // Allows the comment editor to control the overall form's completeness.
   @Input() isFormPending?: boolean;
@@ -80,14 +81,14 @@ export class CommentEditorComponent implements OnInit {
   }
 
   checkPlaceHolderOnFocus() {
-    if (this.commentField.value === 'No details provided.') {
+    if (this.commentField.value === this.defaultValue) {
       this.commentField.setValue('');
     }
   }
 
   checkPlaceHolderOnBlur() {
     if (this.commentField.value === '') {
-      this.commentField.setValue('No details provided.');
+      this.commentField.setValue(this.defaultValue);
     }
   }
 

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -8,6 +8,7 @@ import {
 import { ErrorHandlingService } from '../../core/services/error-handling.service';
 import { HttpErrorResponse } from '@angular/common/http';
 import { ElectronService } from '../../core/services/electron.service';
+import { LoggingService } from '../../core/services/logging.service';
 
 const DISPLAYABLE_CONTENT = ['gif', 'jpeg', 'jpg', 'png'];
 const BYTES_PER_MB = 1000000;
@@ -24,7 +25,8 @@ export class CommentEditorComponent implements OnInit {
 
   constructor(private uploadService: UploadService,
               private errorHandlingService: ErrorHandlingService,
-              private electronService: ElectronService) {}
+              private electronService: ElectronService,
+              private logger: LoggingService) {}
 
   @Input() commentField: AbstractControl; // Compulsory Input
   @Input() commentForm: FormGroup; // Compulsory Input
@@ -62,6 +64,7 @@ export class CommentEditorComponent implements OnInit {
     }
 
     this.initialSubmitButtonText = this.submitButtonText;
+    this.logger.startSession();
   }
 
   onDragEnter(event) {
@@ -76,6 +79,23 @@ export class CommentEditorComponent implements OnInit {
     }
   }
 
+  checkPlaceHolderOnFocus() {
+    this.logger.info("onfocus event");
+    this.logger.info("commentField value: " + this.commentField.value);
+    this.logger.info("initial value: " + this.initialDescription);
+    if (this.commentField.value === 'No details provided.') {
+      this.commentField.setValue('');
+    }
+  }
+
+  checkPlaceHolderOnBlur() {
+    this.logger.info("blur event");
+    this.logger.info("commentField value: " + this.commentField.value);
+    this.logger.info("initial value: " + this.initialDescription);
+    if (this.commentField.value === '') {
+      this.commentField.setValue('No details provided.');
+    }
+  }
   // Prevent cursor in textarea from moving when file is dragged over it.
   disableCaretMovement(event) {
     event.preventDefault();
@@ -187,6 +207,7 @@ export class CommentEditorComponent implements OnInit {
       this.readAndUploadFile(blob);
     }
   }
+
 
   get isInErrorState(): boolean {
     return !!this.uploadErrorMessage;


### PR DESCRIPTION
Autohide the string `No details provided.` in the comment field when the user clicks on the Description text to input the description of the bug. Upon clicking outside of the box, if the user's input is empty, the default string `No details provided.` will appear again. Else, it will show the user's description of the bug.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/66840796/121931724-93890e80-cd76-11eb-8fee-dceffe946171.gif)


Reason:
1. Improve user experience so that they don't have to manually delete the default text whenever they need to submit a new bug report (especially when they have to report a large number of issues during the mock and actual PE)
2. Align with the existing backend database if the comment field is empty (saved as the string `No details provided.`)

Further Improvement:
Right now, I'm using a guard clause that specifically (hardcoded) checks the `value` of the `commentField` in the `comment-editor-component` whether it is equal to the string `No details provided.` to hide the description.
More elegant solution might be possible, for example, declare a constant `DEFAULT_DESCRIPTION_VALUE` in `new-issue-component` pass this check down to the `new-issue-component` instead of the more general `comment-editor-component` 